### PR TITLE
fix: 让 agent-rp 预设能在公开版 DSH 上挂载

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12656,7 +12656,8 @@ function installAgentRp(ctx, config, options = {}) {
 		recordInput: false,
 		handler: executeWorldInfoConfiguration
 	});
-	ctx.effect(() => gateway.registerPromptAttachmentConsumer("dsh-agent-rp", ({ agent, content }) => claimAgentRpPrompt(agentsByScope.get(agent) === agent, content)), "agent-rp: prompt attachment consumer");
+	const registerPromptAttachmentConsumer = gateway.registerPromptAttachmentConsumer?.bind(gateway);
+	if (registerPromptAttachmentConsumer !== void 0) ctx.effect(() => registerPromptAttachmentConsumer("dsh-agent-rp", ({ agent, content }) => claimAgentRpPrompt(agentsByScope.get(agent) === agent, content)), "agent-rp: prompt attachment consumer");
 	const registerSessionImporter = gateway.registerPromptSessionImporter?.bind(gateway);
 	if (registerSessionImporter !== void 0) ctx.effect(() => registerSessionImporter("dsh-agent-rp:sillytavern-migration", {
 		recognize: ({ agent, content }) => isSillyTavernMigrationOffer(agentsByScope.get(agent) === agent, content),

--- a/src/index.ts
+++ b/src/index.ts
@@ -454,9 +454,14 @@ export function installAgentRp(
     recordInput: false,
     handler: executeWorldInfoConfiguration,
   })
-  ctx.effect(() => gateway.registerPromptAttachmentConsumer('dsh-agent-rp', ({ agent, content }) => (
-    claimAgentRpPrompt(agentsByScope.get(agent) === agent, content)
-  )), 'agent-rp: prompt attachment consumer')
+  // The prompt-attachment consumer gateway arrived after the public 0.1.0-rc.6
+  // apiProxy; feature-detect it so the preset mounts on the public release too.
+  const registerPromptAttachmentConsumer = gateway.registerPromptAttachmentConsumer?.bind(gateway)
+  if (registerPromptAttachmentConsumer !== undefined) {
+    ctx.effect(() => registerPromptAttachmentConsumer('dsh-agent-rp', ({ agent, content }) => (
+      claimAgentRpPrompt(agentsByScope.get(agent) === agent, content)
+    )), 'agent-rp: prompt attachment consumer')
+  }
   const registerSessionImporter = gateway.registerPromptSessionImporter?.bind(gateway)
   if (registerSessionImporter !== undefined) ctx.effect(() => registerSessionImporter('dsh-agent-rp:sillytavern-migration', {
     recognize: ({ agent, content }) => isSillyTavernMigrationOffer(agentsByScope.get(agent) === agent, content),


### PR DESCRIPTION
## 问题

在公开版 DSH（`@deepseek-ai/dsh` 0.1.0-rc.6，npm 上最新发布版）上，agent-rp 预设无法挂载，导致**无法创建新会话**：

```
agent-presets: preset "agent-rp" failed to mount: failed to apply loader entry agent-rp-character (@dsh-external/dsh-agent-rp): gateway.registerPromptAttachmentConsumer is not a function
```

`apiProxy.registerPromptAttachmentConsumer` 是更新版 DSH `apiProxy` 才有的接口，公开版 0.1.0-rc.6 的运行时里不存在。character 模式入口在激活时抛错，`session.create`（新建会话）随之返回 `agent-preset-invalid`。

## 修复

注册前先做特性检测，与紧邻的 `registerPromptSessionImporter` 可选调用方式保持一致：

```ts
const registerPromptAttachmentConsumer = gateway.registerPromptAttachmentConsumer?.bind(gateway)
if (registerPromptAttachmentConsumer !== undefined) {
  ctx.effect(() => registerPromptAttachmentConsumer('dsh-agent-rp', ({ agent, content }) => (
    claimAgentRpPrompt(agentsByScope.get(agent) === agent, content)
  )), 'agent-rp: prompt attachment consumer')
}
```

在提供该网关的 DSH 版本上行为不变；在公开版上预设可以正常挂载，其余 RP 流程（角色库、会话导入器、工具）继续走原有的降级路径。

## 验证

- 修复前：`POST /api/session.create` 携带 `agentPreset: "agent-rp"` → 返回 `agent-preset-invalid` 及上述错误。
- 修复后：同样的请求返回 `{ ok: true, value: { sessionId, agentPreset: "agent-rp" } }`。

## 备注

- `lib/index.js` 已由补丁后的源码重新构建（仓库惯例是提交构建产物）；客户端 bundle 不受本次改动影响。
- 即使以后新版 DSH `apiProxy` 发布，这个特性检测也可以保留——在新版本上它是空操作。
