### PR TITLE
fix: drop empty hint from rp-tavern-trigger command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -479,7 +479,6 @@ export function installAgentRp(
   commands.register({
     name: 'rp-tavern-trigger',
     description: 'generate a roleplay reply after a Tavern script appends a user message',
-    input: { hint: '' },
     recordInput: false,
     handler: executeTavernTrigger,
   })


### PR DESCRIPTION
## Problem

On DeepSeek Harness `0.1.0-rc.6` (the latest published release), every character-mode feature that relies on session commands is unavailable — the client reports errors like `当前 Host 未启用预设库` (preset library / world info / persona / generation / drawing all affected).

## Root cause

`installAgentRp` registers `rp-tavern-trigger` with `input: { hint: '' }`. The host commands service rejects an empty hint:

```
TypeError: command "rp-tavern-trigger" input hint must not be empty
    at normalizeDefinition (@deepseek-ai/dsh-commands)
```

Because this is the first `commands.register` call in `installAgentRp`, the throw aborts character-mode activation and the remaining eleven `/rp-*` commands are never registered. Host-mode (HTTP) features are unaffected, which makes the failure look like a data problem in the UI (the preset library dialog swallows the list error and renders as empty).

## Fix

Remove the empty `input` field — it is optional, and this command takes no input. One-line change.

## Verification

Instrumented the built plugin on dsh `0.1.0-rc.6`: before the fix, character-mode `apply` throws the TypeError above; after removing the empty hint, `installAgentRp` completes successfully and all character services (`agents`, `apiProxy`, `attachments`, `commands`, `credentials`, `llm`, `systemPrompt`, `tools`) resolve. `pnpm typecheck` and `pnpm build` pass.