### PR TITLE
fix: allow already active roleplay resources

### DIFF
--- a/lib/extension-v0.d.ts
+++ b/lib/extension-v0.d.ts
@@ -68,7 +68,7 @@ interface RoleplayResourceProvider {
   list(): readonly RoleplayResourceDescriptor[];
   /** Return bounded kind-specific presentation details without exposing source payloads. */
   inspect?(descriptor: RoleplayResourceDescriptor): RoleplayResourceDetail;
-  /** Freeze one owned selection into a complete replayable Session-event prefix. */
+  /** Preserve the Session-event prefix and append a snapshot when the selection is not already active. */
   materialize?(input: RoleplayResourceMaterializationInput): RoleplayResourceMaterialization;
 }
 /** Source-neutral facts shared with each provider while a new experience is assembled. */
@@ -83,7 +83,7 @@ interface RoleplayResourceMaterializationInput {
   readonly events: readonly SessionEvent[];
   readonly context: RoleplayResourceMaterializationContext;
 }
-/** Complete event prefix after one provider has appended its immutable snapshot. */
+/** Complete event prefix after one provider has preserved it and optionally appended a snapshot. */
 interface RoleplayResourceMaterialization {
   readonly events: readonly SessionEvent[];
   readonly title?: string;

--- a/lib/index.js
+++ b/lib/index.js
@@ -775,7 +775,7 @@ var RoleplayResourceCatalog = class {
 		if (typeof result === "object" && result !== null && "then" in result && typeof result.then === "function") throw new Error(`Roleplay resource provider ${JSON.stringify(located.providerId)} must materialize synchronously`);
 		if (typeof result !== "object" || result === null || !Array.isArray(result.events)) throw new Error(`Roleplay resource provider ${JSON.stringify(located.providerId)} returned invalid Session events`);
 		const next = structuredClone(result.events);
-		if (next.length <= prefix.length || !next.slice(0, prefix.length).every((event, index) => isDeepStrictEqual(event, prefix[index]))) throw new Error(`Roleplay resource provider ${JSON.stringify(located.providerId)} must only append Session events`);
+		if (next.length < prefix.length || !next.slice(0, prefix.length).every((event, index) => isDeepStrictEqual(event, prefix[index]))) throw new Error(`Roleplay resource provider ${JSON.stringify(located.providerId)} must only append Session events`);
 		if (next.some((event, index) => event.seq !== index)) throw new Error(`Roleplay resource provider ${JSON.stringify(located.providerId)} returned non-contiguous Session events`);
 		const validated = Session.create(SessionId("agent-rp-resource-materialization-validation"), next);
 		const title = typeof result.title === "string" ? result.title.trim() : void 0;
@@ -23772,8 +23772,8 @@ function navigableSeed(events) {
 }
 /**
 * Materialize independently selected resources in semantic experience order.
-* Providers may only append immutable Session events; their source formats never
-* become part of this assembly contract.
+* Providers preserve the current Session prefix and append immutable events when
+* the selected resource is not already active; source formats stay provider-owned.
 */
 function prepareRoleplayExperienceSession(catalog, selection) {
 	const worlds = selection.worlds ?? [];

--- a/src/roleplay-experience-materialization.ts
+++ b/src/roleplay-experience-materialization.ts
@@ -43,8 +43,8 @@ function navigableSeed(events: readonly SessionEvent[]): readonly SessionEvent[]
 
 /**
  * Materialize independently selected resources in semantic experience order.
- * Providers may only append immutable Session events; their source formats never
- * become part of this assembly contract.
+ * Providers preserve the current Session prefix and append immutable events when
+ * the selected resource is not already active; source formats stay provider-owned.
  */
 export function prepareRoleplayExperienceSession(
   catalog: RoleplayResourceCatalog,

--- a/src/roleplay-resource-catalog.ts
+++ b/src/roleplay-resource-catalog.ts
@@ -28,7 +28,7 @@ export interface RoleplayResourceProvider {
   list(): readonly RoleplayResourceDescriptor[]
   /** Return bounded kind-specific presentation details without exposing source payloads. */
   inspect?(descriptor: RoleplayResourceDescriptor): RoleplayResourceDetail
-  /** Freeze one owned selection into a complete replayable Session-event prefix. */
+  /** Preserve the Session-event prefix and append a snapshot when the selection is not already active. */
   materialize?(input: RoleplayResourceMaterializationInput): RoleplayResourceMaterialization
 }
 
@@ -46,7 +46,7 @@ export interface RoleplayResourceMaterializationInput {
   readonly context: RoleplayResourceMaterializationContext
 }
 
-/** Complete event prefix after one provider has appended its immutable snapshot. */
+/** Complete event prefix after one provider has preserved it and optionally appended a snapshot. */
 export interface RoleplayResourceMaterialization {
   readonly events: readonly SessionEvent[]
   readonly title?: string
@@ -245,7 +245,7 @@ export class RoleplayResourceCatalog {
       throw new Error(`Roleplay resource provider ${JSON.stringify(located.providerId)} returned invalid Session events`)
     }
     const next = structuredClone(result.events)
-    if (next.length <= prefix.length
+    if (next.length < prefix.length
       || !next.slice(0, prefix.length).every((event, index) => isDeepStrictEqual(event, prefix[index]))) {
       throw new Error(`Roleplay resource provider ${JSON.stringify(located.providerId)} must only append Session events`)
     }

--- a/tests/roleplay-experience-materialization.test.ts
+++ b/tests/roleplay-experience-materialization.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import test from 'node:test'
 import { Session, SessionId } from '@deepseek-ai/dsh-session'
 import { CharacterLibrary } from '../src/character-library.ts'
+import { CharacterWorldBindingStore } from '../src/character-world-binding-store.ts'
 import { readActiveSessionCharacter } from '../src/import/session-character.ts'
 import { readActiveSessionPreset } from '../src/import/session-preset.ts'
 import { readActiveSessionWorldInfos } from '../src/import/session-world-info.ts'
@@ -44,11 +45,16 @@ import { agentRpProjectionDefinition } from '../src/projection.ts'
 function fixture(context: test.TestContext) {
   const root = mkdtempSync(join(tmpdir(), 'agent-rp-experience-materialization-'))
   context.after(() => { rmSync(root, { recursive: true, force: true }) })
-  const characters = new CharacterLibrary({ root: join(root, 'characters') })
+  const bindings = new CharacterWorldBindingStore({ root: join(root, 'character-world-bindings') })
+  const worldInfos = new WorldInfoLibrary({ root: join(root, 'worlds'), bindings })
+  const characters = new CharacterLibrary({
+    root: join(root, 'characters'),
+    worldInfoLibrary: worldInfos,
+    worldBindings: bindings,
+  })
   const personas = new PersonaLibrary({ root: join(root, 'personas') })
   const presets = new PresetLibrary({ root: join(root, 'presets') })
   const regexPacks = new RegexPackLibrary({ root: join(root, 'regex-packs') })
-  const worldInfos = new WorldInfoLibrary({ root: join(root, 'worlds') })
   const chats = new SillyTavernChatLibrary({ root: join(root, 'chats') })
   const character = characters.importFile({
     data: new TextEncoder().encode(JSON.stringify({
@@ -167,6 +173,51 @@ test('materializes five independent resources into one exact replayable characte
     }),
   })
   assert.equal(plan.prompt.transforms.operations[0]?.owner, 'regex')
+})
+
+test('keeps one snapshot when an actor-bound world is also selected explicitly', context => {
+  const value = fixture(context)
+  const binding = value.characters.get(value.character.id).worldBinding
+  assert.ok(binding !== undefined)
+  value.characters.updateWorldBinding(value.character.id, {
+    format: 0,
+    revision: binding.revision,
+    primaryWorldInfoId: value.world.id,
+    additionalWorldInfoIds: [],
+  })
+  const actorId = characterLibraryRoleplayResourceId(value.character.id)
+  const worldId = worldInfoLibraryRoleplayResourceId(value.world.id)
+  const request = parseAgentRpSessionLaunchRequest({
+    format: 0,
+    sourceSessionId: 'source-session',
+    kind: 'experience',
+    mode: 'character',
+    actor: { kind: 'actor', id: actorId },
+    worlds: [{ kind: 'world', id: worldId }],
+  })
+  if (request.kind !== 'experience') assert.fail('experience request was not parsed')
+  const prepared = prepareAgentRpSession(
+    value.characters,
+    value.chats,
+    value.presets,
+    value.worldInfos,
+    request,
+    value.catalog,
+  )
+  const session = Session.create(SessionId('bound-world-selected-explicitly'), prepared.seed)
+
+  assert.deepEqual(readActiveSessionWorldInfos(session.events).map(entry => ({
+    attachmentId: entry.result.sourceAttachmentId,
+    placement: entry.placement,
+    purpose: entry.purpose,
+  })), [{
+    attachmentId: `library:${value.world.id}`,
+    placement: 'actor',
+    purpose: 'character-binding',
+  }])
+  assert.deepEqual(readRoleplayExperienceSelection(session.events)?.worlds, [{
+    kind: 'world', id: worldId,
+  }])
 })
 
 test('normalizes older experience provenance without a regex-pack selection', () => {

--- a/tests/roleplay-resource-catalog.test.ts
+++ b/tests/roleplay-resource-catalog.test.ts
@@ -103,6 +103,17 @@ test('dispatches materialization to the owner while enforcing append-only Sessio
   assert.deepEqual(first.events.map(event => event.seq), [0, 1])
 
   catalog.register({
+    id: 'fixture:world-no-op',
+    list: () => [{ id: 'world:existing', kind: 'world', name: '已有世界', availability: 'available' }],
+    materialize: input => ({ events: input.events }),
+  })
+  assert.deepEqual(catalog.materialize(
+    { kind: 'world', id: 'world:existing' },
+    first.events,
+    { mode: 'character' },
+  ).events, first.events)
+
+  catalog.register({
     id: 'fixture:world-rewriter',
     list: () => [{ id: 'world:rewrite', kind: 'world', name: '错误世界', availability: 'available' }],
     materialize: input => ({ events: input.events.slice(1) }),


### PR DESCRIPTION
## Summary

- allow a resource provider to preserve an unchanged Session-event prefix when the selected resource is already active
- continue rejecting providers that remove, rewrite, reorder, or append non-contiguous Session events
- cover the regression where a character-bound World Info resource is selected explicitly in the same experience
- keep only the actor-owned World Info snapshot while retaining the explicit experience selection provenance
- rebuild the published Host bundle and public extension declarations

## Root cause

The World Info provider intentionally returned the existing event prefix when a character binding had already materialized the selected world. The catalog treated a zero-event append as a prefix violation and raised `Roleplay resource provider "agent-rp:world-info-library" must only append Session events`.

## Validation

- targeted resource catalog and experience materialization tests — 12 passed
- `pnpm run test:focused` — 650 tests, 648 passed and 2 skipped
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run check:published-imports`