### PR TITLE
chore(release): prepare npm prerelease publishing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+src/client/tavern-vendor-sources.generated.ts text eol=lf
+src/tavern-local-modules.generated.ts text eol=lf
 host-runner/patches/*.patch -whitespace

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,0 +1,87 @@
+name: Publish npm prerelease
+
+on:
+  pull_request:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Verify release package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the reviewed revision
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: 24.x
+      - name: Install frozen dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Require a prerelease on main
+        if: github.event_name == 'release'
+        env:
+          RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          test "$RELEASE_IS_PRERELEASE" = "true" || { echo "Only GitHub prereleases may publish this package." >&2; exit 1; }
+          git fetch origin main
+          git merge-base --is-ancestor HEAD origin/main || { echo "The release tag is not on main." >&2; exit 1; }
+          node scripts/check-prerelease-package.mjs --tag "$RELEASE_TAG"
+      - name: Build and pack the public artifact
+        run: |
+          mkdir -p .release-dist
+          pnpm pack --out .release-dist/dsh-agent-rp.tgz
+      - name: Audit the exact tarball
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+        run: |
+          if [ -n "$RELEASE_TAG" ]; then
+            node scripts/check-prerelease-package.mjs --tag "$RELEASE_TAG" --tarball .release-dist/dsh-agent-rp.tgz
+          else
+            node scripts/check-prerelease-package.mjs --tarball .release-dist/dsh-agent-rp.tgz
+          fi
+      - name: Retain the reviewed release artifact
+        if: github.event_name == 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: npm-prerelease-${{ github.event.release.tag_name }}
+          path: .release-dist/dsh-agent-rp.tgz
+          retention-days: 7
+
+  publish:
+    name: Publish reviewed tarball
+    if: github.event_name == 'release'
+    needs: package
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Require npm trusted-publishing support
+        run: >-
+          node -e "const [major, minor] = require('node:child_process').execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim().split('.').map(Number); if (major < 11 || (major === 11 && minor < 5)) throw new Error('npm 11.5.1 or newer is required for trusted publishing')"
+      - name: Download the reviewed tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-prerelease-${{ github.event.release.tag_name }}
+          path: .release-dist
+      - name: Publish with npm trusted publishing
+        run: npm publish .release-dist/dsh-agent-rp.tgz --access public --tag next --provenance

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -11,19 +11,19 @@ permissions:
 jobs:
   package:
     name: Verify release package
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Check out the reviewed revision
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           run_install: false
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           cache: pnpm
           node-version: 24.x
@@ -35,26 +35,27 @@ jobs:
           RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          test "$RELEASE_IS_PRERELEASE" = "true" || { echo "Only GitHub prereleases may publish this package." >&2; exit 1; }
+          if ($env:RELEASE_IS_PRERELEASE -ne 'true') { throw 'Only GitHub prereleases may publish this package.' }
           git fetch origin main
-          git merge-base --is-ancestor HEAD origin/main || { echo "The release tag is not on main." >&2; exit 1; }
-          node scripts/check-prerelease-package.mjs --tag "$RELEASE_TAG"
+          git merge-base --is-ancestor HEAD origin/main
+          if ($LASTEXITCODE -ne 0) { throw 'The release tag is not on main.' }
+          node scripts/check-prerelease-package.mjs --tag $env:RELEASE_TAG
       - name: Build and pack the public artifact
         run: |
-          mkdir -p .release-dist
+          [System.IO.Directory]::CreateDirectory((Join-Path $PWD '.release-dist')) | Out-Null
           pnpm pack --out .release-dist/dsh-agent-rp.tgz
       - name: Audit the exact tarball
         env:
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
         run: |
-          if [ -n "$RELEASE_TAG" ]; then
-            node scripts/check-prerelease-package.mjs --tag "$RELEASE_TAG" --tarball .release-dist/dsh-agent-rp.tgz
-          else
+          if ([string]::IsNullOrEmpty($env:RELEASE_TAG)) {
             node scripts/check-prerelease-package.mjs --tarball .release-dist/dsh-agent-rp.tgz
-          fi
+          } else {
+            node scripts/check-prerelease-package.mjs --tag $env:RELEASE_TAG --tarball .release-dist/dsh-agent-rp.tgz
+          }
       - name: Retain the reviewed release artifact
         if: github.event_name == 'release'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           if-no-files-found: error
           name: npm-prerelease-${{ github.event.release.tag_name }}
@@ -72,14 +73,14 @@ jobs:
       id-token: write
     steps:
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.x
       - name: Require npm trusted-publishing support
         run: >-
           node -e "const [major, minor] = require('node:child_process').execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim().split('.').map(Number); if (major < 11 || (major === 11 && minor < 5)) throw new Error('npm 11.5.1 or newer is required for trusted publishing')"
       - name: Download the reviewed tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-prerelease-${{ github.event.release.tag_name }}
           path: .release-dist

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,6 +6,7 @@ Agent RP publishes npm prereleases as `@dsh-external/dsh-agent-rp` under the `ne
 
 - The version in `package.json` and GitHub tag must match exactly as `0.0.0-rc.N` and `v0.0.0-rc.N`.
 - The tagged commit must already belong to `main`, and the GitHub Release must be marked as a prerelease.
+- The package job runs on a GitHub-hosted Windows runner so the checked-in browser vendor payloads are verified with their canonical generation toolchain; every platform installs the same audited tarball.
 - `.github/workflows/publish-prerelease.yml` builds and packs once, audits that exact tarball, and passes the retained artifact to the publish job.
 - npm publication uses GitHub OIDC trusted publishing with provenance. The repository does not store an npm automation token.
 - User installation documentation changes only after a clean install and an update from an older npm prerelease both succeed.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,41 @@
+# Prerelease publication
+
+Agent RP publishes npm prereleases as `@dsh-external/dsh-agent-rp` under the `next` dist-tag. A published version is immutable; a bad release is deprecated and `next` is moved back to a known-good version instead of overwriting or routinely unpublishing it.
+
+## Release policy
+
+- The version in `package.json` and GitHub tag must match exactly as `0.0.0-rc.N` and `v0.0.0-rc.N`.
+- The tagged commit must already belong to `main`, and the GitHub Release must be marked as a prerelease.
+- `.github/workflows/publish-prerelease.yml` builds and packs once, audits that exact tarball, and passes the retained artifact to the publish job.
+- npm publication uses GitHub OIDC trusted publishing with provenance. The repository does not store an npm automation token.
+- User installation documentation changes only after a clean install and an update from an older npm prerelease both succeed.
+
+Run the same package checks locally before preparing the release commit:
+
+```powershell
+pnpm install --frozen-lockfile
+pnpm pack --out .release-dist/dsh-agent-rp.tgz
+$version = node -p "require('./package.json').version"
+node scripts/check-prerelease-package.mjs --tag "v$version" --tarball .release-dist/dsh-agent-rp.tgz
+```
+
+The pack lifecycle runs the vendored-runtime check, product build, published-import consumers, and prerelease manifest policy before producing the tarball.
+
+## One-time npm bootstrap
+
+The first publication must reserve the previously unused package name before npm can attach a trusted publisher to it. This is the only non-OIDC publication. A maintainer signs in interactively with `npm login --auth-type=web`, publishes the already audited tarball with `--access public --tag next --provenance=false`, and then runs `npm logout`. The explicit override is required because local terminals cannot issue CI provenance. Do not create or paste an npm automation token into GitHub, a terminal transcript, an Issue, or repository settings.
+
+Immediately after the package exists, configure its npm trusted publisher with:
+
+- repository owner: `hewzhew`
+- repository: `dsh-agent-rp`
+- workflow: `publish-prerelease.yml`
+- GitHub environment: `npm`
+
+All later releases are created as GitHub prereleases from an exact `v0.0.0-rc.N` tag. The workflow must be the only publisher after bootstrap.
+
+After one OIDC release succeeds, set npm Publishing access to “Require two-factor authentication and disallow tokens”. The trusted publisher remains authorized because it uses short-lived OIDC credentials rather than a traditional npm token.
+
+## Recovery
+
+If a release is unusable, preserve its GitHub Release and provenance record, mark the npm version deprecated with a concrete reason, and move `next` back to the last verified version. Publish a new incremented rc for the fix. Unpublish only when npm policy, credential exposure, or a legal requirement makes removal necessary.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,33 @@
 {
   "name": "@dsh-external/dsh-agent-rp",
-  "version": "0.0.0-rc.249",
-  "private": true,
+  "version": "0.0.0-rc.250",
+  "private": false,
+  "description": "Native roleplay runtime and SillyTavern compatibility plugin for DeepSeek Harness.",
   "license": "MIT",
+  "author": "Ocheron",
+  "homepage": "https://github.com/hewzhew/dsh-agent-rp#readme",
+  "bugs": {
+    "url": "https://github.com/hewzhew/dsh-agent-rp/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hewzhew/dsh-agent-rp.git"
+  },
+  "keywords": [
+    "deepseek-harness",
+    "dsh",
+    "roleplay",
+    "sillytavern"
+  ],
+  "engines": {
+    "node": "^22.19.0 || >=24.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "registry": "https://registry.npmjs.org/",
+    "tag": "next"
+  },
   "type": "module",
   "main": "./lib/index.js",
   "bin": {
@@ -60,12 +85,13 @@
     "benchmark:compat": "tsdown benchmarks/heavy-card.ts --no-config --format esm --platform node --target es2024 --out-dir .benchmark-dist --clean && node .benchmark-dist/heavy-card.mjs",
     "generate:tavern-vendor": "node scripts/generate-tavern-vendor-sources.mjs",
     "check:tavern-vendor": "node scripts/generate-tavern-vendor-sources.mjs --check",
+    "check:release": "node scripts/check-prerelease-package.mjs",
     "clean:generated": "tsx scripts/clean-generated.ts",
     "smoke:compat": "tsdown --config tsdown.smoke.config.ts && node .smoke-dist/smoke-card-compat.mjs",
     "build": "tsdown",
     "build:host": "tsdown --config tsdown.host.config.ts",
     "check:published-imports": "node scripts/check-published-imports.mjs && tsc -p tsconfig.published-client-extension.json && tsdown fixtures/published-client-extension-consumer.ts --no-config --format cjs --platform browser --target es2024 --out-dir .test-dist/published-client-extension --clean && node scripts/check-published-client-extension.mjs",
-    "prepack": "pnpm run check:tavern-vendor && pnpm run build && pnpm run check:published-imports",
+    "prepack": "pnpm run check:tavern-vendor && pnpm run build && pnpm run check:published-imports && pnpm run check:release",
     "test": "node scripts/run-source-tests.mjs all",
     "test:external-window": "node scripts/run-source-tests.mjs external-window",
     "test:http": "node scripts/run-source-tests.mjs http",

--- a/scripts/check-prerelease-package.mjs
+++ b/scripts/check-prerelease-package.mjs
@@ -1,0 +1,117 @@
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const PACKAGE_NAME = '@dsh-external/dsh-agent-rp'
+const REGISTRY = 'https://registry.npmjs.org/'
+const VERSION_PATTERN = /^0\.0\.0-rc\.(?:0|[1-9]\d*)$/u
+const EXPECTED_FILES = [
+  'LICENSE',
+  'lib/index.js',
+  'lib/extension-v0.js',
+  'lib/extension-v0.d.ts',
+  'lib/client-extension-v0.js',
+  'lib/client-extension-v0.d.ts',
+  'lib/repair-session.js',
+  'lib/client.js',
+  'lib/client.js.map',
+  'cordis.patch.yml',
+  'docs',
+  'preset',
+]
+const REQUIRED_TARBALL_FILES = [
+  'package/LICENSE',
+  'package/README.md',
+  'package/cordis.patch.yml',
+  'package/docs/troubleshooting.md',
+  'package/lib/client-extension-v0.d.ts',
+  'package/lib/client-extension-v0.js',
+  'package/lib/client.js',
+  'package/lib/client.js.map',
+  'package/lib/extension-v0.d.ts',
+  'package/lib/extension-v0.js',
+  'package/lib/index.js',
+  'package/lib/repair-session.js',
+  'package/package.json',
+  'package/preset/agent.cordis.yml',
+  'package/preset/preset.yml',
+]
+
+function fail(message) {
+  throw new Error(`Prerelease package check failed: ${message}`)
+}
+
+function parseArguments(arguments_) {
+  const result = {}
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index]
+    if (argument !== '--tag' && argument !== '--tarball') fail(`unknown argument ${JSON.stringify(argument)}`)
+    const value = arguments_[index + 1]
+    if (value === undefined || value.startsWith('--')) fail(`${argument} requires a value`)
+    result[argument.slice(2)] = value
+    index += 1
+  }
+  return result
+}
+
+function validateManifest(manifest) {
+  if (manifest.name !== PACKAGE_NAME) fail(`package name must be ${PACKAGE_NAME}`)
+  if (!VERSION_PATTERN.test(manifest.version)) fail('version must match 0.0.0-rc.N')
+  if (manifest.private !== false) fail('private must be explicitly false')
+  if (manifest.license !== 'MIT') fail('license must be MIT')
+  if (manifest.repository?.url !== 'git+https://github.com/hewzhew/dsh-agent-rp.git') {
+    fail('repository must identify the public source repository')
+  }
+  if (manifest.publishConfig?.access !== 'public') fail('publishConfig.access must be public')
+  if (manifest.publishConfig?.provenance !== true) fail('publishConfig.provenance must be true')
+  if (manifest.publishConfig?.registry !== REGISTRY) fail(`publishConfig.registry must be ${REGISTRY}`)
+  if (manifest.publishConfig?.tag !== 'next') fail('publishConfig.tag must be next')
+  if (JSON.stringify(manifest.files) !== JSON.stringify(EXPECTED_FILES)) {
+    fail('files must remain the reviewed package allowlist')
+  }
+}
+
+function validateTag(version, tag) {
+  if (tag !== undefined && tag !== `v${version}`) fail(`release tag must be v${version}, received ${tag}`)
+}
+
+function tar(arguments_) {
+  const result = spawnSync('tar', arguments_, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 })
+  if (result.error !== undefined) fail(`could not run tar: ${result.error.message}`)
+  if (result.status !== 0) fail(`tar exited with ${String(result.status)}: ${result.stderr.trim()}`)
+  return result.stdout
+}
+
+function validateTarball(tarball, sourceManifest, tag) {
+  const archive = resolve(tarball)
+  const entries = tar(['-tzf', archive]).split(/\r?\n/u).filter(Boolean)
+  const uniqueEntries = new Set(entries)
+  if (uniqueEntries.size !== entries.length) fail('tarball contains duplicate paths')
+  for (const entry of entries) {
+    if (!entry.startsWith('package/') || entry.includes('/../') || entry.includes('\\')) {
+      fail(`tarball contains unsafe path ${JSON.stringify(entry)}`)
+    }
+    const allowed = REQUIRED_TARBALL_FILES.includes(entry)
+      || /^package\/docs\/[^/]+\.md$/u.test(entry)
+    if (!allowed) fail(`tarball contains unreviewed file ${JSON.stringify(entry)}`)
+  }
+  for (const required of REQUIRED_TARBALL_FILES) {
+    if (!uniqueEntries.has(required)) fail(`tarball is missing ${required}`)
+  }
+  const packedManifest = JSON.parse(tar(['-xOzf', archive, 'package/package.json']))
+  validateManifest(packedManifest)
+  validateTag(packedManifest.version, tag)
+  if (packedManifest.name !== sourceManifest.name || packedManifest.version !== sourceManifest.version) {
+    fail('packed manifest identity differs from the source manifest')
+  }
+}
+
+const options = parseArguments(process.argv.slice(2))
+const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+validateManifest(manifest)
+validateTag(manifest.version, options.tag)
+if (options.tarball !== undefined) validateTarball(options.tarball, manifest, options.tag)
+
+console.log(options.tarball === undefined
+  ? `Prerelease manifest ${manifest.name}@${manifest.version} is publishable on the next tag.`
+  : `Prerelease tarball ${manifest.name}@${manifest.version} matches the reviewed package policy.`)


### PR DESCRIPTION
## Summary

- publish rc.250 as a public package under the npm next dist-tag
- verify the exact packed artifact and reject mismatched release tags or unexpected files
- add a GitHub OIDC trusted-publishing workflow and maintainer recovery procedure

Progresses #10. The Issue remains open until the first package publish, clean install, and cross-rc update are verified.

## Local verification

- pnpm pack --out .release-dist/dsh-agent-rp.tgz
- node scripts/check-prerelease-package.mjs --tag v0.0.0-rc.250 --tarball .release-dist/dsh-agent-rp.tgz
- npm publish .release-dist/dsh-agent-rp.tgz --access public --tag next --dry-run
- actionlint v1.7.12 .github/workflows/publish-prerelease.yml
- git diff --cached --check

## Hosted verification

- GitHub Actions run 32960033281 passed the frozen install, build, pack, and exact tarball audit on the release runner.