### PR TITLE
chore(release): prepare 0.0.0-rc.252

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hewzhew/dsh-agent-rp",
-  "version": "0.0.0-rc.251",
+  "version": "0.0.0-rc.252",
   "private": false,
   "description": "Native roleplay runtime and SillyTavern compatibility plugin for DeepSeek Harness.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- advance the package version to `0.0.0-rc.252`
- validate the newly configured npm trusted publisher for `hewzhew/dsh-agent-rp`, `.github/workflows/publish-prerelease.yml`, and the `npm` GitHub environment
- keep product and compatibility behavior unchanged

## Release validation

After this PR passes and merges, publish GitHub prerelease `v0.0.0-rc.252`. The release workflow must rebuild and audit the reviewed tag, authenticate to npm through GitHub OIDC without an npm token, publish under the `next` dist-tag, and attach npm provenance.

## Local verification

- `pnpm pack --out .release-dist/dsh-agent-rp-rc252.tgz` — passed
- `node scripts/check-prerelease-package.mjs --tag v0.0.0-rc.252 --tarball .release-dist/dsh-agent-rp-rc252.tgz` — passed
- `git diff --check` — passed