### PR TITLE
chore: install prereleases from npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Character Card、Chat Completion 预设、World Info、MVU、EJS 和 Tavern Help
 
 ## 安装
 
-需要 Node.js 22.19+ 或 24+，以及 pnpm 11。没有 pnpm 时可以先运行 `npm install --global pnpm@11`。安装器会准备经过验证的 Agent Host、安装或更新 Agent RP，并保留 `~/.dsh` 中已有的角色与会话；它不会静默安装全局工具。
+需要 Node.js 22.19+ 或 24+，以及 pnpm 11。没有 pnpm 时可以先运行 `npm install --global pnpm@11`。安装器会准备经过验证的 Agent Host，从 npm 的 `next` 标签安装或更新 Agent RP，并保留 `~/.dsh` 中已有的角色与会话；它不会静默安装全局工具。
 
 ### DSH Desktop
 
@@ -29,7 +29,7 @@ DSH Desktop 使用自己封装的 Node、pnpm、DSH Host、数据目录和当前
 若只需协助验证纯对话兼容，可以从 Desktop 托盘打开它自带的 DSH Terminal，在当前激活的 profile 中安装插件后重启 Desktop：
 
 ```powershell
-dsh plugin add github:hewzhew/dsh-agent-rp#main
+dsh plugin add '@hewzhew/dsh-agent-rp@next'
 ```
 
 这条路径尚未列为完整支持入口。不要运行下面的 Windows 安装器来“覆盖” Desktop；它会创建一个独立 Agent Host，而不会修改 Desktop 安装包内部的运行时。完整支持需要 Desktop Host 提供与 Agent Host 等价的安全插件事件接口，或允许 Desktop 连接到经过验证的外部 Host。
@@ -52,7 +52,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File $installerPath -Start
 
 设置过 `DSH_HOME` 时，安装器会打印该数据目录中的实际启动路径。不要改回 `npx -p @deepseek-ai/dsh@latest dsh --profile web`；这会重新进入尚未包含插件事件能力的官方 runner。若界面提示当前 Host 缺少安全插件事件能力，请关闭旧 DSH 后从上述专用入口启动。安装器发现默认端口 3080 已被其他进程占用时不会停止它或再启动第二个 DSH，而会显示进程 PID 和后续命令。
 
-国内 npm registry 较慢时，可在安装器最后一行加 `-ChinaMirror`。这个选项只改变本次安装使用的 npm registry；下载 runner 文件或 Agent RP 源码时访问的是 GitHub，切换 npm 镜像不会修复这一段。
+国内 npm registry 较慢时，可在安装器最后一行加 `-ChinaMirror`。这个选项会同时用于 Agent Host 依赖和 Agent RP 包；安装器脚本与 runner 文件仍从 GitHub 下载。
 
 ### macOS
 
@@ -130,7 +130,7 @@ Termux 路线面向 ARM64、Android 11 及以上设备，目标是在手机本�
 
 遇到脚本加载、世界书 EJS、行动选项、工作区归属或「RP 互通」问题时，先按 [使用与故障排查](docs/troubleshooting.md) 取得对应失败详情；匿名「复制诊断」不能替代具体错误。
 
-需要比较大型卡片改动时，可运行不含社区卡片内容的 [合成兼容基准与本地真实卡、预设验收流程](docs/compatibility-benchmark.md)。EJS 的可执行与保留范围见 [EJS 兼容表](docs/ejs-compatibility.md)；后续世界书与插件生态遵循 [安全扩展能力协议](docs/extension-capabilities.md)。独立 DSH 插件可从 [社区插件接入](docs/community-plugin-development.md) 选择 Host 生命周期接口或 Agent RP 工作台 Slot；安装型第三方扩展另按 [SillyTavern 扩展宿主](docs/st-extension-host.md) 的单例生命周期设计。当前仍是源码与本地安装协作入口，不代表 npm 分发已经完成。
+需要比较大型卡片改动时，可运行不含社区卡片内容的 [合成兼容基准与本地真实卡、预设验收流程](docs/compatibility-benchmark.md)。EJS 的可执行与保留范围见 [EJS 兼容表](docs/ejs-compatibility.md)；后续世界书与插件生态遵循 [安全扩展能力协议](docs/extension-capabilities.md)。独立 DSH 插件可从 [社区插件接入](docs/community-plugin-development.md) 选择 Host 生命周期接口或 Agent RP 工作台 Slot；安装型第三方扩展另按 [SillyTavern 扩展宿主](docs/st-extension-host.md) 的单例生命周期设计。npm `next` 提供经过发布门禁与 provenance 证明的预发布包；源码分支仍只用于贡献和定向验收。
 
 ## 反馈与贡献
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,6 +22,10 @@ node scripts/check-prerelease-package.mjs --tag "v$version" --tarball .release-d
 
 The pack lifecycle runs the vendored-runtime check, product build, published-import consumers, and prerelease manifest policy before producing the tarball.
 
+## Installer promotion
+
+The Windows, macOS, and Linux installers default to `@hewzhew/dsh-agent-rp@next`. Keep the explicit plugin-source option for local directories and review branches, but do not point ordinary installs at `main`. Before changing user documentation for a new package line, verify the published tarball from a clean DSH home, rerun the installer against the same profile to exercise the update path, and start the resulting web profile once. The installer scripts and pinned Agent Host runner files remain hosted on GitHub; the plugin payload and its transitive dependencies come from the selected npm registry.
+
 ## One-time npm bootstrap
 
 The first publication must reserve the previously unused package name before npm can attach a trusted publisher to it. This is the only non-OIDC publication. A maintainer signs in interactively with `npm login --auth-type=web`, publishes the already audited tarball with `--access public --tag next --provenance=false`, and then runs `npm logout`. The explicit override is required because local terminals cannot issue CI provenance. Do not create or paste an npm automation token into GitHub, a terminal transcript, an Issue, or repository settings.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@
 
 ## 更新后仍像旧版本
 
-使用 README 中与当前平台对应的安装器更新，并重启实际提供页面的 DSH Host。直接安装 GitHub 版本时，不要继续固定到旧提交；例如 `github:hewzhew/dsh-agent-rp#ac55cca` 永远只会安装该提交。反馈时请同时提供平台、DSH 启动方式和实际安装的 Agent RP Git 引用。
+使用 README 中与当前平台对应的安装器更新，并重启实际提供页面的 DSH Host。默认安装器跟随 npm 的 `next` 标签；直接安装 GitHub 版本时，不要继续固定到旧提交，例如 `github:hewzhew/dsh-agent-rp#ac55cca` 永远只会安装该提交。反馈时请同时提供平台、DSH 启动方式、安装来源和实际安装的 Agent RP 版本。
 
 不要只凭 DSH 的版本号判断 Host 能力。DSH Desktop、官方 runner 和 Agent Host 可能显示相同版本号，却包含不同的插件接口；各入口的支持范围见 README 的安装章节。
 
@@ -45,4 +45,4 @@
 
 ## 提交 Issue 前
 
-请提供预期表现、实际表现、最短复现步骤、平台、DSH 启动方式和 Agent RP Git 引用。不要上传 API Key、NPM Token、完整私人对话、无权再分发的角色卡或完整 Session Log。脚本与世界书的「复制失败详情」已经限制内容范围，优先使用这两个入口。
+请提供预期表现、实际表现、最短复现步骤、平台、DSH 启动方式、Agent RP 安装来源和版本。不要上传 API Key、NPM Token、完整私人对话、无权再分发的角色卡或完整 Session Log。脚本与世界书的「复制失败详情」已经限制内容范围，优先使用这两个入口。

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 umask 077
 
 DSH_VERSION="${DSH_VERSION:-0.1.1-rc.2}"
-PLUGIN_SOURCE="${PLUGIN_SOURCE:-github:hewzhew/dsh-agent-rp#main}"
+PLUGIN_SOURCE="${PLUGIN_SOURCE:-@hewzhew/dsh-agent-rp@next}"
 RUNNER_SOURCE_BASE="${RUNNER_SOURCE_BASE:-https://raw.githubusercontent.com/hewzhew/dsh-agent-rp/main/host-runner}"
 REGISTRY="${REGISTRY:-}"
 AGENT_HOST_PORT="${AGENT_HOST_PORT:-3080}"
@@ -39,7 +39,7 @@ usage() {
 用法：bash install-linux.sh [选项]
 
   --dsh-version <v>        Agent Host 版本；必须等于当前验收版本
-  --plugin-source <spec>   插件来源，默认 github:hewzhew/dsh-agent-rp#main
+  --plugin-source <spec>   插件来源，默认 @hewzhew/dsh-agent-rp@next
   --runner-source-base <u> runner 文件来源；可使用 URL 或本地目录
   --registry <url>         本次安装使用的 npm registry
   --china-mirror           使用 https://registry.npmmirror.com

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 umask 077
 
 DSH_VERSION="${DSH_VERSION:-0.1.1-rc.2}"
-PLUGIN_SOURCE="${PLUGIN_SOURCE:-github:hewzhew/dsh-agent-rp#main}"
+PLUGIN_SOURCE="${PLUGIN_SOURCE:-@hewzhew/dsh-agent-rp@next}"
 RUNNER_SOURCE_BASE="${RUNNER_SOURCE_BASE:-https://raw.githubusercontent.com/hewzhew/dsh-agent-rp/main/host-runner}"
 REGISTRY="${REGISTRY:-}"
 AGENT_HOST_PORT="${AGENT_HOST_PORT:-3080}"
@@ -38,7 +38,7 @@ usage() {
 用法：bash install-macos.sh [选项]
 
   --dsh-version <v>        Agent Host 版本；必须等于当前验收版本
-  --plugin-source <spec>   插件来源，默认 github:hewzhew/dsh-agent-rp#main
+  --plugin-source <spec>   插件来源，默认 @hewzhew/dsh-agent-rp@next
   --runner-source-base <u> runner 文件来源；可使用 URL 或本地目录
   --registry <url>         本次安装使用的 npm registry
   --china-mirror           使用 https://registry.npmmirror.com

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,7 +1,7 @@
 ﻿[CmdletBinding()]
 param(
   [string]$DshVersion = '0.1.1-rc.2',
-  [string]$PluginSource = 'github:hewzhew/dsh-agent-rp#main',
+  [string]$PluginSource = '@hewzhew/dsh-agent-rp@next',
   [string]$RunnerSourceBase = 'https://raw.githubusercontent.com/hewzhew/dsh-agent-rp/main/host-runner',
   [string]$Registry,
   [switch]$ChinaMirror,
@@ -290,7 +290,7 @@ try {
 } catch {
   Write-Host "安装失败：$($_.Exception.Message)" -ForegroundColor Red
   Write-Host '如果卡在“准备 Agent Host”的依赖安装，可以重试 -ChinaMirror；若下载 runner 文件失败，则需要检查 GitHub 连通性。' -ForegroundColor Yellow
-  Write-Host '如果卡在“安装 Agent RP”，访问的是 GitHub；切换 npm 镜像不会修复这一段。' -ForegroundColor Yellow
+  Write-Host '如果卡在“安装 Agent RP”，可以重试 -ChinaMirror；runner 文件仍需要访问 GitHub。' -ForegroundColor Yellow
   exit 1
 } finally {
   if ($null -eq $previousRegistry) {

--- a/tests/install-macos.test.ts
+++ b/tests/install-macos.test.ts
@@ -18,6 +18,7 @@ import test, { type TestContext } from 'node:test'
 const repositoryRoot = resolve(import.meta.dirname, '..')
 const installer = resolve(repositoryRoot, 'scripts/install-macos.sh')
 const pluginPackageName = '@hewzhew/dsh-agent-rp'
+const defaultPluginSource = '@hewzhew/dsh-agent-rp@next'
 const pluginSource = 'github:hewzhew/dsh-agent-rp#fixture'
 
 interface InstallerFixtureOptions {
@@ -193,6 +194,17 @@ function commandLog(fixture: InstallerFixture): Array<{
 }
 
 const skip = process.platform === 'win32'
+
+test('desktop installers default to the npm next prerelease', () => {
+  const windows = readFileSync(resolve(repositoryRoot, 'scripts/install-windows.ps1'), 'utf8')
+  const macos = readFileSync(installer, 'utf8')
+  const linux = readFileSync(resolve(repositoryRoot, 'scripts/install-linux.sh'), 'utf8')
+
+  assert.match(windows, new RegExp(`PluginSource = '${defaultPluginSource}'`, 'u'))
+  for (const source of [macos, linux]) {
+    assert.match(source, new RegExp(`PLUGIN_SOURCE="\\$\\{PLUGIN_SOURCE:-${defaultPluginSource}\\}"`, 'u'))
+  }
+})
 
 test('shows macOS installer options without touching the host', { skip }, () => {
   const result = spawnSync('/bin/bash', [installer, '--help'], { encoding: 'utf8' })


### PR DESCRIPTION
## Summary
- make Windows, macOS, and Linux installers install `@hewzhew/dsh-agent-rp@next` by default
- keep explicit source overrides for local and review builds
- update installation, release, and troubleshooting documentation for Registry delivery
- lock the three platform defaults with a source-level regression test

## Verification
- `pnpm test` (769 tests: 757 passed, 12 skipped)
- `pnpm run typecheck`
- `pnpm run check:release`
- PowerShell parser check for `scripts/install-windows.ps1`
- `bash -n scripts/install-macos.sh scripts/install-linux.sh`
- clean Windows install from npm Registry into a fresh DSH home
- same-profile installer rerun with `0.0.0-rc.252` retained from `next`
- installed web profile started successfully and returned HTTP 200